### PR TITLE
Move Nepeta's documentation into README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # Exobar
+Exobar is a status bar tweak that utilizes [Exo](https://github.com/KritantaDev/Exo) as its data provider.
 
-Documentation: https://web.archive.org/web/20190608050611/https://docs.nepeta.me/exo/exobar
+***Note**: This documentation is unfinished, as certain parts of Nepeta's original documentation were lost/never documented. We're sorry about this!*
+
+### Actions
+- ``enableInteraction``: Enables user interaction with the status bar
+
+### Variables
+| Variable name | Type | Description |
+|-------------------|-----------------|-----------------|
+| exobar.cc | boolean | ``true`` if the status bar is currently visible inside of the control center |
+| exobar.modern | boolean | ``true`` if the current device uses a modern status bar |
+| exobar.dark | boolean | ``true`` if the foreground (text) is supposed to be dark |
+| exobar.disableBurnInProtection | boolean | ``true`` if the user requests the burn in protection to be disabled |
+| exobar.breadcrumb | boolean | ``true`` if a breadcrumb is present |
+| exobar.breadcrumb.title | string | 	Title of the breadcrumb |
+| exobar.breadcrumb.bundle | string | Bundle ID of the breadcrumb (to use with ``open.application``) |


### PR DESCRIPTION
This should be most of the documentation about Exobar from Nepeta's documentation page. Some parts may be missing as the Wayback Machine only archives what it wants to.